### PR TITLE
Implémenter un réseau bayésien qui utilise l'inférence par énumération

### DIFF
--- a/bayesian/__init__.py
+++ b/bayesian/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'plperron'

--- a/bayesian/discrete/__init__.py
+++ b/bayesian/discrete/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'plperron'

--- a/bayesian/discrete/distribution.py
+++ b/bayesian/discrete/distribution.py
@@ -1,0 +1,28 @@
+u"""
+Modelise un reseau compose uniquement de variables discretes.
+"""
+
+
+class Distribution():
+    def __init__(self, probabilities):
+        self.probabilities = probabilities
+
+    def normalize(self):
+        total = sum(self.get_probabilities())
+        self.probabilities = [prob / total for prob in self.probabilities]
+        return self
+
+    def set_probability(self, index, probability):
+        assert 0 <= index < len(self.probabilities)
+        assert 0. <= probability <= 1.
+        self.probabilities[index] = probability
+        return self
+
+    def get_probabilities(self):
+        return self.probabilities[:]
+
+    def get_probability(self):
+        return self.probabilities[0]
+
+
+__author__ = 'plperron'

--- a/bayesian/discrete/inference.py
+++ b/bayesian/discrete/inference.py
@@ -1,0 +1,65 @@
+from bayesian.proposition import Evidence
+
+
+class Inference(object):
+    def infer(self, query, evidences, bn):
+        pass
+
+
+class EnumerationAsk():
+    def __init__(self):
+        pass
+
+    def infer(self, query, evidences, bn):
+        # Q = a distribution over X, where Q(xi) is P(X=xi)
+        distribution = bn.get_variable_by_name(query.get_variable_name()).calc_probabilities()
+        # for each value xi that X can have do
+        evidences = evidences[:]
+        evidences.append(None)
+        topological_vars = bn.get_variable_in_topological_order()
+        domains = bn.get_variable_by_name(query.get_variable_name()).get_domains()
+        for d in range(0, len(domains)):
+            # Q(xi) = ENUMERATE-ALL(bn.VARS, e_xi), where e_xi is the evidence e plus the assignment X=xi
+            evidences[len(evidences) - 1] = Evidence(query.get_variable_name(), domains[d])
+            distribution.set_probability(d, self.__enumerate_all(topological_vars, evidences))
+        # return NORMALIZE(Q)
+        return bn.get_variable_by_name(query.get_variable_name()).get_probability_from(distribution.normalize(),
+            query.get_domain_value())
+
+    def __enumerate_all(self, topological_vars, evidences):
+        # if EMPTY(vars) then return 1.0
+        if len(topological_vars) == 0:
+            return 1.
+        # Y = FIRST(vars)
+        first = topological_vars[0]
+        topological_vars = topological_vars[1:]
+        # if Y is assigned a value (call it y) in e then
+        if self.__is_assigned(first, evidences):
+            return first.calcProbabilities(evidences).get_probability() * \
+                   self.__enumerate_all(topological_vars, evidences)
+        else:
+            evidences = evidences[:]
+            evidences.append(None)
+            somme = 0.
+            for domain in first.get_domains():
+                evidences[len(evidences) - 1] = Evidence(first.get_name(), domain)
+                somme += first.calcProbabilities(evidences).get_probability() * \
+                         self.__enumerate_all(topological_vars, evidences)
+            return somme
+
+    def __is_assigned(self, var, evidences):
+        for evidence in evidences:
+            if evidence.is_evidence_of(var):
+                return True
+        return False
+
+
+class EliminationAsk():
+    def __init__(self):
+        pass
+
+    def infer(self, query, evidences, bn):
+        pass
+
+
+__author__ = 'plperron'

--- a/bayesian/discrete/network.py
+++ b/bayesian/discrete/network.py
@@ -1,0 +1,16 @@
+class DiscreteBayesianNetwork:
+    def __init__(self, vars):
+        self.vars = vars
+
+    def get_variable_by_name(self, name):
+        return self.vars[name]
+
+    def infer(self, proposition, inference):
+        return inference.infer(proposition.get_query(), proposition.get_evidences(), self)
+
+    def get_variable_in_topological_order(self):
+        sorted_vars = [v for k, v in self.vars.iteritems()]
+        return sorted(sorted_vars, key=lambda var: var.height())
+
+
+__author__ = 'plperron'

--- a/bayesian/discrete/network_test.py
+++ b/bayesian/discrete/network_test.py
@@ -1,0 +1,65 @@
+import unittest
+
+from network import DiscreteBayesianNetwork
+from distribution import Distribution
+from variable import RandomVariable
+from bayesian.proposition import *
+from inference import EnumerationAsk
+
+
+class BayesianNetworkTestCase(unittest.TestCase):
+    def setUp(self):
+        name = "burglar"
+        domains = ["false", "true"]
+        parents = []
+        distribution = Distribution([.999, .001])
+        burglar = RandomVariable(name, parents, domains, distribution)
+        name = "earthquake"
+        domains = ["false", "true"]
+        parents = []
+        distribution = Distribution([.998, .002])
+        earthquake = RandomVariable(name, parents, domains, distribution)
+        name = "alarm"
+        domains = ["false", "true"]
+        parents = [burglar, earthquake]
+        distribution = Distribution([.999, .001, .71, .29, .06, .94, .05, .95])
+        alarm = RandomVariable(name, parents, domains, distribution)
+        name = "john"
+        domains = ["false", "true"]
+        parents = [alarm]
+        distribution = Distribution([.95, .05, .1, .9])
+        john = RandomVariable(name, parents, domains, distribution)
+        name = "mary"
+        domains = ["false", "true"]
+        parents = [alarm]
+        distribution = Distribution([.99, .01, .3, .7])
+        mary = RandomVariable(name, parents, domains, distribution)
+        vars = {"burglar": burglar, "earthquake": earthquake, "alarm": alarm, "john": john, "mary": mary}
+        self.bn = DiscreteBayesianNetwork(vars)
+
+    def test_infer_simple(self):
+        evidences = []
+        proposition = Proposition(Query("burglar", "false"), evidences)
+        actual = self.bn.infer(proposition, EnumerationAsk())
+        expect = .999
+        self.assertEqual(expect, actual)
+
+    def test_infer_simple2(self):
+        evidences = []
+        proposition = Proposition(Query("burglar", "true"), evidences)
+        actual = self.bn.infer(proposition, EnumerationAsk())
+        expect = .001
+        self.assertEqual(expect, actual)
+
+    def test_infer_russel_norvig_burglar_example(self):
+        evidences = [Evidence("john", "true"), Evidence("mary", "true")]
+        proposition = Proposition(Query("burglar", "true"), evidences)
+        actual = self.bn.infer(proposition, EnumerationAsk())
+        expect = .2841718353643929
+        self.assertEqual(expect, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+__author__ = 'plperron'

--- a/bayesian/discrete/variable.py
+++ b/bayesian/discrete/variable.py
@@ -1,0 +1,83 @@
+u"""
+Modelise une variable discrete d'un reseau bayesien.
+"""
+
+from distribution import Distribution
+
+
+class RandomVariable():
+    def __init__(self, name, parents, domains, distribution):
+        self.name = name
+        self.parents = parents
+        self.__domains = domains
+        self.distribution = distribution
+
+    def get_name(self):
+        return self.name
+
+    def get_domains(self):
+        return self.__domains[:]
+
+    def get_probability_from(self, distribution, domain):
+        probabilities = distribution.get_probabilities()
+        assert len(probabilities) == len(self.__domains)
+        indexes = [d for d in range(0, len(self.__domains)) if self.__domains[d] == domain]
+        assert len(indexes) == 1
+        return probabilities[indexes[0]]
+
+    def height(self):
+        """La hauteur se definit par le nombre de parents, grand-parents...etc"""
+        maximum = 0.
+        for parent in self.parents:
+            maximum = max(maximum, parent.height())
+        return 1 + maximum
+
+    def calcProbabilities(self, evidences):
+        """
+        Elage les evidences excedentaires et calcule la probabilite selon les evidences pertinentes restantes
+        :param evidences:
+        :return:
+        """
+        topological_evidences = self.__sort_by_topological_order(evidences)
+        topological_variables = self.parents[:]
+        topological_variables.append(self)
+        assert len(topological_variables) == len(topological_evidences)
+        probabilitites = self.distribution.get_probabilities()
+        start, count = 0, len(probabilitites)
+        for i in range(0, len(topological_evidences)):
+            domains = topological_variables[i].get_domains()
+            for d in range(0, len(domains)):
+                if domains[d] == topological_evidences[i].get_domain_value():
+                    start += count / len(domains) * d
+                    count /= len(domains)
+                    break
+        assert count == 1
+        return Distribution(probabilitites[start: start + count])
+
+    def __sort_by_topological_order(self, evidences):
+        topological_evidences = [None] * (len(self.parents) + 1)
+        i = 0
+        for parent in self.parents:
+            for evidence in evidences:
+                if parent.get_name() == evidence.get_variable_name():
+                    topological_evidences[i] = evidence
+                    i += 1
+                    break
+        for evidence in evidences:
+            if evidence.get_variable_name() == self.get_name():
+                topological_evidences[i] = evidence
+                i += 1
+                break
+        assert i == len(topological_evidences)
+        return topological_evidences
+
+    def calc_probabilities(self):
+        probabilities = self.distribution.get_probabilities()
+        domain_probabilities = [0.] * len(self.get_domains())
+        for d in range(0, len(self.get_domains())):
+            for p in range(d, len(probabilities), len(self.get_domains())):
+                domain_probabilities[d] += probabilities[p]
+        return Distribution(domain_probabilities).normalize()
+
+
+__author__ = 'plperron'

--- a/bayesian/proposition.py
+++ b/bayesian/proposition.py
@@ -1,0 +1,50 @@
+"""
+Modelise les operateurs necessaires lors de requetes sur un reseau bayesien.
+Les 3 classes _Affectation, Query et Evidence sont identiques.
+Ici, ils different pour clarifier la semantique
+"""
+
+
+class _Affectation(object):
+    def __init__(self, variable_name, domain_value):
+        self.variable_name = variable_name
+        self.domain_value = domain_value
+
+    def get_variable_name(self):
+        return self.variable_name
+
+    def get_domain_value(self):
+        return self.domain_value
+
+
+class Query(_Affectation):
+    def __init__(self, variable_name, domain_value):
+        super(Query, self).__init__(variable_name, domain_value)
+
+
+class Evidence(_Affectation):
+    def __init__(self, variable_name, domain_value):
+        super(Evidence, self).__init__(variable_name, domain_value)
+
+    def is_evidence_of(self, variable):
+        if variable.get_name() != super(Evidence, self).get_variable_name():
+            return False
+        for domain in variable.get_domains():
+            if domain == super(Evidence, self).get_domain_value():
+                return True
+        return False
+
+
+class Proposition():
+    def __init__(self, query, evidences):
+        self.query = query
+        self.evidences = evidences
+
+    def get_query(self):
+        return self.query
+
+    def get_evidences(self):
+        return self.evidences[:]
+
+
+__author__ = 'plperron'


### PR DESCRIPTION
Implémenter un réseau bayésien qui utilise l'inférence par énumération

Un réseau bayésien et un graphique qui modélise des relation de cause à effet.  L'inférence permet de calculer la probabilité statistique d'un évèvement lors de l'observation de faits.

Le réseau est testé avec les exemples de russel et norvig.  